### PR TITLE
Add JSON-LD Person schema to head and remove runtime injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,17 @@
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content="https://www.westcoastcelebrants.ie/og-logo.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Carmel Fitzgerald",
+        "jobTitle": "Wedding Celebrant & Solemniser",
+        "worksFor": { "@type": "Organization", "name": "West Coast Celebrants" },
+        "email": "mailto:westcoastcelebrants@gmail.com",
+        "areaServed": ["County Mayo", "County Galway", "County Sligo", "West of Ireland"]
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/Website.tsx
+++ b/src/Website.tsx
@@ -238,22 +238,6 @@ const weddingPhotos = [
     return () => { document.body.style.overflow = ""; };
   }, [menuOpen]);
 
-  useEffect(() => {
-    const s = document.createElement("script");
-    s.type = "application/ld+json";
-    s.innerHTML = JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "Person",
-      name: "Carmel Fitzgerald",
-      jobTitle: "Wedding Celebrant & Solemniser",
-      worksFor: { "@type": "Organization", name: "West Coast Celebrants" },
-      email: "mailto:westcoastcelebrants@gmail.com",
-      areaServed: ["County Mayo", "County Galway", "County Sligo", "West of Ireland"],
-    });
-    document.head.appendChild(s);
-    return () => { s.remove(); };
-  }, []);
-
   return (
     <div
       className={cx("min-h-screen", isDark ? "bg-slate-950 text-slate-100" : "bg-white text-slate-900")}

--- a/src/site/SiteLayout.tsx
+++ b/src/site/SiteLayout.tsx
@@ -76,24 +76,6 @@ export function SiteLayout() {
     };
   }, [menuOpen]);
 
-  useEffect(() => {
-    const script = document.createElement("script");
-    script.type = "application/ld+json";
-    script.innerHTML = JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "Person",
-      name: "Carmel Fitzgerald",
-      jobTitle: "Wedding Celebrant & Solemniser",
-      worksFor: { "@type": "Organization", name: "West Coast Celebrants" },
-      email: "mailto:westcoastcelebrants@gmail.com",
-      areaServed: ["County Mayo", "County Galway", "County Sligo", "West of Ireland"],
-    });
-    document.head.appendChild(script);
-    return () => {
-      script.remove();
-    };
-  }, []);
-
   const navBase = useMemo(
     () => (isDark ? "text-slate-200 hover:text-white" : "text-slate-700 hover:text-slate-900"),
     [isDark]


### PR DESCRIPTION
### Motivation
- Ensure the site includes a static `application/ld+json` Person schema in the page head so structured data is available to crawlers immediately.
- Remove duplicate/runtime injection of the same JSON-LD from React components to avoid duplication and improve SEO consistency.

### Description
- Added a static JSON-LD Person script block to `index.html` with `@context`, `@type: Person`, `name`, `jobTitle`, `worksFor`, `email`, and `areaServed` fields.
- Removed runtime `useEffect` blocks that created and appended the same `application/ld+json` script from `src/site/SiteLayout.tsx` and `src/Website.tsx`.
- Net change: modified `index.html`, `src/site/SiteLayout.tsx`, and `src/Website.tsx` to centralize structured data in the static head.

### Testing
- No automated tests were run against these changes.
- A commit was created with the updated files and there were no build/test steps executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69869fefc2848328b64db983ee798f34)