### PR TITLE
Add JSON-LD structured data (ProfessionalService, Person, FAQ) and refresh sitemap lastmod

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,70 +2,70 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.westcoastcelebrants.ie/</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/about</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/services</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/gallery</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/how-it-works</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/recommendations</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/faq</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/contact</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/weddings</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/vow-renewals</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/naming</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/celebration-of-life</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/your-funeral</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/privacy</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/terms</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/payment-policy</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
   <url>
     <loc>https://www.westcoastcelebrants.ie/cookies</loc>
-    <lastmod>2026-02-06</lastmod>
+    <lastmod>2026-02-07</lastmod>
   </url>
 </urlset>

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -1,6 +1,7 @@
 import { Section } from "../site/Section";
 import { usePageMeta } from "../site/usePageMeta";
 import { useTheme } from "../site/useTheme";
+import { useJsonLd } from "../site/useJsonLd";
 
 function cx(...parts: Array<string | false | null | undefined>) {
   return parts.filter(Boolean).join(" ");
@@ -8,12 +9,56 @@ function cx(...parts: Array<string | false | null | undefined>) {
 
 export function FAQPage() {
   const { isDark } = useTheme();
+  const questions = [
+    {
+      question: "How far in advance should we book?",
+      answer: "As soon as you have a venue or date in mind. Popular dates book quickly, so get in touch and we will check availability.",
+    },
+    {
+      question: "Is there a legal notice period in Ireland?",
+      answer:
+        "Yes. Couples must give at least 3 months civil notice to the HSE before a legal wedding. We will guide you through the paperwork, ID requirements, and appointment booking, including for destination couples travelling to Ireland.",
+    },
+    {
+      question: "How quickly do you respond?",
+      answer: "We reply within 24 hours. For urgent Celebration of Life enquiries, please call +353 87 130 2029.",
+    },
+    {
+      question: "Do you travel?",
+      answer: "Yes. Westport based, officiating across the West of Ireland (Mayo, Galway, Sligo, Roscommon and beyond by arrangement).",
+    },
+    {
+      question: "Do you work with LGBTQ+ couples?",
+      answer: "Absolutely. All couples are welcome — LGBTQ+, intercultural, interfaith, and secular ceremonies.",
+    },
+    {
+      question: "How fast can a Celebration of Life be arranged?",
+      answer:
+        "We prioritise these enquiries and draft quickly. Please call for urgent dates; memorial services can also be planned weeks or months after a passing.",
+    },
+  ];
 
   usePageMeta({
     title: "FAQ",
     description: "Common questions about ceremonies with West Coast Celebrants.",
     path: "/faq",
   });
+
+  useJsonLd(
+    JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: questions.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    }),
+    "faq"
+  );
 
   return (
     <Section title="FAQ" kicker="Good to know">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { Calendar, ChevronRight } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useTheme } from "../site/useTheme";
 import { usePageMeta } from "../site/usePageMeta";
+import { useJsonLd } from "../site/useJsonLd";
 
 function cx(...parts: Array<string | false | null | undefined>) {
   return parts.filter(Boolean).join(" ");
@@ -9,13 +10,40 @@ function cx(...parts: Array<string | false | null | undefined>) {
 
 export function HomePage() {
   const { isDark } = useTheme();
+  const description =
+    "West Coast Celebrants, led by Carmel Fitzgerald, creates heartfelt weddings, vow renewals, naming ceremonies, and celebrations of life across the West of Ireland.";
 
   usePageMeta({
     title: "Ceremonies crafted with heart",
-    description:
-      "West Coast Celebrants, led by Carmel Fitzgerald, creates heartfelt weddings, vow renewals, naming ceremonies, and celebrations of life across the West of Ireland.",
+    description,
     path: "/",
   });
+
+  useJsonLd(
+    JSON.stringify({
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "ProfessionalService",
+          "@id": "https://www.westcoastcelebrants.ie/#professionalservice",
+          name: "West Coast Celebrants",
+          url: "https://www.westcoastcelebrants.ie/",
+          description,
+          logo: "https://www.westcoastcelebrants.ie/og-logo.png",
+          image: "https://www.westcoastcelebrants.ie/og-logo.png",
+          founder: { "@id": "https://www.westcoastcelebrants.ie/#carmel-fitzgerald" },
+        },
+        {
+          "@type": "Person",
+          "@id": "https://www.westcoastcelebrants.ie/#carmel-fitzgerald",
+          name: "Carmel Fitzgerald",
+          jobTitle: "Celebrant",
+          worksFor: { "@id": "https://www.westcoastcelebrants.ie/#professionalservice" },
+        },
+      ],
+    }),
+    "home"
+  );
 
   return (
     <>

--- a/src/site/useJsonLd.ts
+++ b/src/site/useJsonLd.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+export function useJsonLd(json: string, id: string) {
+  useEffect(() => {
+    const scriptId = `jsonld-${id}`;
+    let script = document.head.querySelector<HTMLScriptElement>(`#${scriptId}`);
+
+    if (!script) {
+      script = document.createElement("script");
+      script.type = "application/ld+json";
+      script.id = scriptId;
+      document.head.appendChild(script);
+    }
+
+    script.textContent = json;
+
+    return () => {
+      script?.remove();
+    };
+  }, [id, json]);
+}


### PR DESCRIPTION
### Motivation
- Improve search discoverability by adding structured data so Google understands the business and the person behind it. 
- Surface FAQ rich results by exposing the existing on-page Q/A as schema without changing visible copy or layout. 
- Improve sitemap quality by adding accurate `<lastmod>` dates and confirm robots/sitemap accessibility.

### Description
- Add a small reusable hook `src/site/useJsonLd.ts` that injects `application/ld+json` scripts into the document head. 
- Inject `ProfessionalService` (Organization) and `Person` JSON-LD on the homepage in `src/pages/Home.tsx`, reusing the existing homepage description and `og-logo.png` asset, and referencing the person `Carmel Fitzgerald` because she is named on the site. 
- Add `FAQPage` JSON-LD to `src/pages/FAQ.tsx` by extracting the visible Q/A pairs exactly as rendered on the page. 
- Update `public/sitemap.xml` to set `<lastmod>` to today (local date) for every URL. 
- Did not change page copy, layout, styling, routing, or add external dependencies; left `public/robots.txt` unchanged as it already contains `User-agent: *`, `Allow: /`, and the `Sitemap:` line.

### Testing
- No automated tests were added or executed for this change; changes were validated by inspecting the modified files and confirming the injected JSON-LD shape and sitemap updates locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a135ed2c8328be29b54766e20896)