### PR TITLE
Update route fallback styling and warm common routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import "./App.css";
 import { ThemeProvider } from "./site/theme";
@@ -26,6 +26,19 @@ const CookiesPage = lazy(() => import("./pages/Cookies").then((m) => ({ default:
 const NotFoundPage = lazy(() => import("./pages/NotFound").then((m) => ({ default: m.NotFoundPage })));
 
 export default function App() {
+  useEffect(() => {
+    const warmRoutes = () => {
+      void import("./pages/About");
+      void import("./pages/Services");
+      void import("./pages/Gallery");
+      void import("./pages/Contact");
+      void import("./pages/FAQ");
+    };
+
+    const timeout = window.setTimeout(warmRoutes, 0);
+    return () => window.clearTimeout(timeout);
+  }, []);
+
   return (
     <ThemeProvider>
       <BrowserRouter>

--- a/src/site/RouteFallback.tsx
+++ b/src/site/RouteFallback.tsx
@@ -9,24 +9,36 @@ export function RouteFallback() {
   const { isDark } = useTheme();
 
   return (
-    <div className={cx("w-full", isDark ? "text-slate-200" : "text-slate-700")}>
-      <div className="max-w-[82rem] mx-auto px-4 sm:px-6 lg:px-10 py-10">
-        <div
-          className={cx(
-            "rounded-2xl border p-6",
-            isDark ? "border-slate-800 bg-slate-950" : "border-slate-200 bg-white"
-          )}
-        >
-          <div className="flex items-center gap-3">
-            <div className="h-4 w-4 rounded-full animate-pulse bg-[var(--brand-teal)]" aria-hidden="true" />
-            <p className="font-semibold">Loading...</p>
-          </div>
-          <p className={cx("mt-2 text-sm", isDark ? "text-slate-300" : "text-slate-600")}>
-            Grabbing the next page.
-          </p>
+    <div
+      className={cx(
+        "w-full min-h-[60vh] flex items-center justify-center px-4 sm:px-6 lg:px-10 py-12",
+        isDark ? "text-slate-200" : "text-slate-700"
+      )}
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div
+        className={cx(
+          "rounded-2xl border px-8 py-7 text-center backdrop-blur",
+          isDark
+            ? "border-slate-800/80 bg-slate-900/50 shadow-[0_20px_60px_rgba(8,11,18,0.35)]"
+            : "border-slate-200/90 bg-white/80 shadow-[0_18px_48px_rgba(15,23,42,0.12)]"
+        )}
+      >
+        <div className="flex items-center justify-center gap-3">
+          <div
+            className={cx(
+              "h-12 w-12 rounded-full border-4 animate-spin",
+              isDark ? "border-slate-700/70 border-t-slate-200" : "border-slate-200/80 border-t-slate-600"
+            )}
+            aria-hidden="true"
+          />
+          <p className="font-semibold">Loading...</p>
         </div>
+        <p className={cx("mt-3 text-sm", isDark ? "text-slate-300" : "text-slate-600")}>
+          Grabbing the next page.
+        </p>
       </div>
     </div>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Users were briefly seeing a black rectangle when route chunks loaded because the Suspense fallback rendered a dark card (`bg-slate-950`) outside the themed surface. 
- The goal is to replace that flicker with a theme-consistent loading UI that preserves page layout and accessibility.

### Description
- Replaced the fallback markup in `src/site/RouteFallback.tsx` with a centered, theme-aware translucent panel that uses `min-h-[60vh]`, a simple spinner, and `aria-busy="true"` / `aria-live="polite"` to avoid layout jumps and improve accessibility. 
- Kept colors driven by the existing `useTheme` state and Tailwind classes so the loading UI blends with both light and dark themes instead of showing a black box. 
- Added a lightweight post-mount prefetch in `src/App.tsx` using `useEffect` that `import()`s a few common pages (`About`, `Services`, `Gallery`, `Contact`, `FAQ`) to reduce the frequency of Suspense falls.

### Testing
- Started the dev server with `npm run dev` and ran a Playwright smoke script that slowed responses and verified the themed fallback rendered; the script completed and produced `artifacts/route-fallback.png` indicating the fallback was visible and not a black box. 
- No existing unit tests were changed and no test failures were observed during the smoke run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a376eb508328898d94f2a03a9489)