### PR TITLE
Normalize canonical URLs and remove forced trailing slashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
         var targetPath = redirect || path;
         if (!targetPath.startsWith("/")) targetPath = "/" + targetPath;
         targetPath = targetPath.toLowerCase();
-        if (!redirect && targetPath !== "/" && !targetPath.endsWith("/")) targetPath += "/";
+        if (targetPath.length > 1 && targetPath.endsWith("/")) targetPath = targetPath.slice(0, -1);
 
         var nextSearch = params.toString();
         var nextUrl = origin + targetPath + (nextSearch ? "?" + nextSearch : "") + (window.location.hash || "");

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,67 +5,67 @@
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/about/</loc>
+    <loc>https://www.westcoastcelebrants.ie/about</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/services/</loc>
+    <loc>https://www.westcoastcelebrants.ie/services</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/gallery/</loc>
+    <loc>https://www.westcoastcelebrants.ie/gallery</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/how-it-works/</loc>
+    <loc>https://www.westcoastcelebrants.ie/how-it-works</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/recommendations/</loc>
+    <loc>https://www.westcoastcelebrants.ie/recommendations</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/faq/</loc>
+    <loc>https://www.westcoastcelebrants.ie/faq</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/contact/</loc>
+    <loc>https://www.westcoastcelebrants.ie/contact</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/weddings/</loc>
+    <loc>https://www.westcoastcelebrants.ie/weddings</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/vow-renewals/</loc>
+    <loc>https://www.westcoastcelebrants.ie/vow-renewals</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/naming/</loc>
+    <loc>https://www.westcoastcelebrants.ie/naming</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/celebration-of-life/</loc>
+    <loc>https://www.westcoastcelebrants.ie/celebration-of-life</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/your-funeral/</loc>
+    <loc>https://www.westcoastcelebrants.ie/your-funeral</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/privacy/</loc>
+    <loc>https://www.westcoastcelebrants.ie/privacy</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/terms/</loc>
+    <loc>https://www.westcoastcelebrants.ie/terms</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/payment-policy/</loc>
+    <loc>https://www.westcoastcelebrants.ie/payment-policy</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/cookies/</loc>
+    <loc>https://www.westcoastcelebrants.ie/cookies</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
 </urlset>

--- a/src/site/usePageMeta.ts
+++ b/src/site/usePageMeta.ts
@@ -21,7 +21,7 @@ function toCanonicalPath(path: string) {
   let normalized = clean.startsWith("/") ? clean : `/${clean}`;
   normalized = normalized.replace(/\/{2,}/g, "/");
   if (normalized === "" || normalized === "/") return "/";
-  return normalized.endsWith("/") ? normalized : `${normalized}/`;
+  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
 }
 
 function setMetaTag(attr: "name" | "property", key: string, value: string) {


### PR DESCRIPTION
### Motivation
- Fix redirect errors caused by inconsistent trailing-slash handling between the client-side SPA fallback and canonical URLs.
- Align runtime canonicalization with the site's route definitions so user-facing URLs and sitemap entries match.

### Description
- Update the SPA fallback script in `index.html` to strip trailing slashes from `targetPath` for non-root paths instead of appending them, preserving case-insensitive normalization for comparison with the current URL.
- Change `toCanonicalPath` in `src/site/usePageMeta.ts` to return canonical paths without a trailing slash (root remains `/`).
- Update `public/sitemap.xml` to remove trailing slashes from all non-root `<loc>` entries so sitemap URLs match the new canonical format.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989189f56a48328af1bf1c91ec95ce7)