### PR TITLE
Align sitemap and canonical URLs with trailing slashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,6 @@
         var targetPath = redirect || path;
         if (!targetPath.startsWith("/")) targetPath = "/" + targetPath;
         targetPath = targetPath.toLowerCase();
-        if (targetPath.length > 1 && targetPath.endsWith("/")) targetPath = targetPath.slice(0, -1);
 
         var nextSearch = params.toString();
         var nextUrl = origin + targetPath + (nextSearch ? "?" + nextSearch : "") + (window.location.hash || "");

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
         var targetPath = redirect || path;
         if (!targetPath.startsWith("/")) targetPath = "/" + targetPath;
         targetPath = targetPath.toLowerCase();
+        if (targetPath.length > 1 && !targetPath.endsWith("/")) targetPath = targetPath + "/";
 
         var nextSearch = params.toString();
         var nextUrl = origin + targetPath + (nextSearch ? "?" + nextSearch : "") + (window.location.hash || "");

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,67 +5,67 @@
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/about</loc>
+    <loc>https://www.westcoastcelebrants.ie/about/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/services</loc>
+    <loc>https://www.westcoastcelebrants.ie/services/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/gallery</loc>
+    <loc>https://www.westcoastcelebrants.ie/gallery/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/how-it-works</loc>
+    <loc>https://www.westcoastcelebrants.ie/how-it-works/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/recommendations</loc>
+    <loc>https://www.westcoastcelebrants.ie/recommendations/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/faq</loc>
+    <loc>https://www.westcoastcelebrants.ie/faq/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/contact</loc>
+    <loc>https://www.westcoastcelebrants.ie/contact/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/weddings</loc>
+    <loc>https://www.westcoastcelebrants.ie/weddings/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/vow-renewals</loc>
+    <loc>https://www.westcoastcelebrants.ie/vow-renewals/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/naming</loc>
+    <loc>https://www.westcoastcelebrants.ie/naming/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/celebration-of-life</loc>
+    <loc>https://www.westcoastcelebrants.ie/celebration-of-life/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/your-funeral</loc>
+    <loc>https://www.westcoastcelebrants.ie/your-funeral/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/privacy</loc>
+    <loc>https://www.westcoastcelebrants.ie/privacy/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/terms</loc>
+    <loc>https://www.westcoastcelebrants.ie/terms/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/payment-policy</loc>
+    <loc>https://www.westcoastcelebrants.ie/payment-policy/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
   <url>
-    <loc>https://www.westcoastcelebrants.ie/cookies</loc>
+    <loc>https://www.westcoastcelebrants.ie/cookies/</loc>
     <lastmod>2026-02-07</lastmod>
   </url>
 </urlset>

--- a/src/site/usePageMeta.ts
+++ b/src/site/usePageMeta.ts
@@ -21,7 +21,7 @@ function toCanonicalPath(path: string) {
   let normalized = clean.startsWith("/") ? clean : `/${clean}`;
   normalized = normalized.replace(/\/{2,}/g, "/");
   if (normalized === "" || normalized === "/") return "/";
-  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+  return normalized.endsWith("/") ? normalized : `${normalized}/`;
 }
 
 function setMetaTag(attr: "name" | "property", key: string, value: string) {


### PR DESCRIPTION
### Motivation
- Google/Search Console reported crawl/indexing problems caused by inconsistent trailing-slash usage between the sitemap, canonical URLs and SPA redirect normalization on GitHub Pages-style route directories.
- The site uses physical route directories on GitHub Pages, so sitemap and canonical URLs must use trailing slashes to match generated route indexes and avoid duplicate/redirected URLs.

### Description
- Added trailing slashes to all non-root `<loc>` entries in `public/sitemap.xml` so sitemap URLs point to directory-style routes.
- Changed `toCanonicalPath` in `src/site/usePageMeta.ts` to preserve and emit a trailing slash for canonical and social `og:url` values.
- Removed client-side code that stripped trailing slashes from SPA fallback normalization in `index.html` so replaced URLs keep their trailing slash.

### Testing
- Ran the sitemap URL checker `node scripts/check-sitemap-urls.mjs` prior to the changes and it reported failures for all 17 sitemap URLs (`0 OK, 17 problem URL(s)`), indicating a crawl/redirect issue.
- No post-change automated checks were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69891dcbdf408328848b8be1f0f88ade)