### PR TITLE
Replace JS 404 redirect with static, crawl-friendly 404 and update robots.txt

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -4,22 +4,63 @@
     <meta charset="UTF-8" />
     <meta name="robots" content="noindex" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>West Coast Celebrants</title>
+    <title>Page not found | West Coast Celebrants</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+
+      main {
+        max-width: 32rem;
+        margin: 1.5rem;
+        padding: 1.5rem;
+        border-radius: 1rem;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+      }
+
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: 1.5rem;
+      }
+
+      p {
+        margin: 0;
+        line-height: 1.6;
+      }
+
+      a {
+        display: inline-block;
+        margin-top: 1rem;
+        color: #2563eb;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      a:hover,
+      a:focus-visible {
+        text-decoration: underline;
+      }
+    </style>
   </head>
   <body>
-    <script>
-      // GitHub Pages SPA fallback: keep the original path in sessionStorage
-      // and redirect to "/" so we avoid creating crawlable ?redirect= URLs.
-      (function () {
-        var loc = window.location;
-        var originalPath = loc.pathname + loc.search + loc.hash;
-        try {
-          window.sessionStorage.setItem("spa-redirect-path", originalPath);
-        } catch (e) {
-          // ignore storage issues and still recover to root
-        }
-        loc.replace(loc.origin + "/");
-      })();
-    </script>
+    <main>
+      <h1>Sorry, we can’t find that page.</h1>
+      <p>
+        The page may have moved, or the URL may be incorrect. Please return to the homepage and continue browsing from there.
+      </p>
+      <a href="/">Go to homepage</a>
+    </main>
   </body>
 </html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
 Allow: /
-Disallow: /*?redirect=*
 Sitemap: https://www.westcoastcelebrants.ie/sitemap.xml


### PR DESCRIPTION
### Motivation

- Search/indexing tools were reporting redirect errors because the old `public/404.html` ran a client-side `location.replace('/')`, which can be treated as a redirect by crawlers instead of a true 404 response. 
- The project should present a static, crawl-friendly 404 page (`noindex`) and stop emitting fallback `?redirect=` URLs.

### Description

- Replaced the JavaScript-based SPA fallback in `public/404.html` with a static, user-friendly 404 page that keeps `meta name="robots" content="noindex"` and a visible link back to the homepage. 
- Removed the client-side `sessionStorage` + `loc.replace` logic to avoid generating crawlable redirects. 
- Removed the obsolete `Disallow: /*?redirect=*` line from `public/robots.txt` since `?redirect=` URLs are no longer produced. 

### Testing

- Ran the test suite with `npm run test:run`, and all tests passed (`30 tests, 9 files`).
- Built the production bundle with `npm run build`, and the build completed successfully and generated static route index files. 
- Previewed the site with `vite preview` and verified the static 404 by loading `/missing-page` (screenshot captured). 
- Ran `node scripts/check-sitemap-urls.mjs` in this environment and it reported remote `fetch failed` errors (this is an external URL check that fails in the sandbox, not related to the 404 fallback change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e104176cc83288e17bf4da431b3c2)